### PR TITLE
Fix MCP JSON-RPC handshake by moving console.log to stderr

### DIFF
--- a/src/database.ts
+++ b/src/database.ts
@@ -148,7 +148,7 @@ export async function initGelClient(): Promise<boolean> {
     // Initialize the default client using the hardcoded default instance
     defaultClient = getDatabaseClient({ instance: 'afca_intelligence' });
     await defaultClient.query('SELECT "Gel MCP Server connection test"');
-    console.log(`Gel database connection successful to instance: afca_intelligence`);
+    console.error(`Gel database connection successful to instance: afca_intelligence`);
     return true;
   } catch (err) {
     console.error('Error connecting to Gel database:', err);

--- a/src/http.ts
+++ b/src/http.ts
@@ -53,7 +53,7 @@ async function main() {
   const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
 
   server.addHook('onClose', async () => {
-    console.log('Shutting down server...');
+    console.error('Shutting down server...');
     await closeAllConnections();
     await transport.close();
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ async function main() {
   console.error('Gel MCP Server running on stdio');
 
   const shutdown = async () => {
-    console.log('Shutting down server...');
+    console.error('Shutting down server...');
     await closeAllConnections();
     await transport.close();
     process.exit(0);


### PR DESCRIPTION
## Problem

The MCP server was showing as red/failed in Cursor's MCP tools integration due to plain text being written to STDOUT during the JSON-RPC handshake process.

## Root Cause

Several `console.log()` statements were polluting STDOUT with messages like:
- "Gel database connection successful to instance: afca_intelligence"
- "Shutting down server..."

The MCP protocol requires clean JSON-RPC communication over STDOUT. Any non-JSON output breaks the handshake and causes client tools to fail.

## Solution

Moved all logging statements from `console.log()` to `console.error()` in:
- `src/database.ts` - Database connection success message
- `src/index.ts` - Server shutdown message  
- `src/http.ts` - HTTP server shutdown message

## Result

- ✅ Cursor MCP tool now shows green (connected) instead of red (failed)
- ✅ STDOUT remains clean for JSON-RPC communication
- ✅ All logging still visible in STDERR for debugging
- ✅ No functional changes to server behavior

## Testing

Verified the fix by:
1. Building the project: `npm run build`
2. Running manually: `node build/index.js` - works correctly
3. Testing in Cursor MCP integration - now shows green status

This is a critical fix for MCP client compatibility. 